### PR TITLE
Adopt the current build and Hub APIs

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Managed by Copier. Records the py-canon template for future updates.
-_commit: v1
+_commit: v1.0.1
 _src_path: gh:gojiplus/py-canon
 author_email: gsood07@gmail.com
 author_name: Gaurav Sood

--- a/README.md
+++ b/README.md
@@ -155,13 +155,11 @@ Classify articles using Large Language Models.
 custom_categories = {
     "breaking": {"description": "Breaking news and urgent updates"},
     "analysis": {"description": "In-depth analysis and commentary"},
-    "lifestyle": {"description": "Lifestyle and entertainment content"}
+    "lifestyle": {"description": "Lifestyle and entertainment content"},
 }
 
 df_custom = notnews.classify_with_llm(
-    df, 
-    provider="claude",
-    categories=custom_categories
+    df, provider="claude", categories=custom_categories
 )
 
 # Fetch content from URLs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.32,<0.13"]
+requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
 [project]
@@ -33,7 +33,7 @@ dependencies = [
     "requests",
     "beautifulsoup4>=4.11.0",
     "click>=8.0.0",
-    "huggingface-hub>=0.23"
+    "huggingface-hub>=1.27.0"
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.18.0" },
     { name = "beautifulsoup4", specifier = ">=4.11.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "huggingface-hub", specifier = ">=0.23" },
+    { name = "huggingface-hub", specifier = ">=1.27.0" },
     { name = "numpy", specifier = ">=1.22.0,<3.0.0" },
     { name = "openai", marker = "extra == 'llm'", specifier = ">=1.12.0" },
     { name = "pandas", specifier = ">=1.3.0" },


### PR DESCRIPTION
Use the fleet's current uv_build 0.12 series and Hugging Face Hub 1.27 public API baseline.

Validated with 35 tests, Ruff, formatting, Pyright, lock validation, uv build, and Twine metadata checks.