### PR TITLE
Ratchet the coverage floor to measured coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     uses: gojiplus/py-canon/.github/workflows/reusable-ci.yml@v1
     with:
       wheel-import: notnews
-      coverage-floor: 35
+      coverage-floor: 46
       run-preen: true
 
   live-models:


### PR DESCRIPTION
Measured 47% (35 passed, 4 live-marker deselected); floor moves 35 → 46 per the fleet ratchet rule (measured rounded down minus 1). No pyproject fail_under (canon wheel-job rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)